### PR TITLE
[codex] correct fee units

### DIFF
--- a/crates/dytallix-cli/src/commands/contract.rs
+++ b/crates/dytallix-cli/src/commands/contract.rs
@@ -330,9 +330,7 @@ where
     let mut convergence = DeployConvergence::default();
 
     loop {
-        if !convergence.tx_visible
-            && services.get_json(&format!("/tx/{tx_hash}")).await.is_ok()
-        {
+        if !convergence.tx_visible && services.get_json(&format!("/tx/{tx_hash}")).await.is_ok() {
             convergence.tx_visible = true;
         }
         if !convergence.contract_visible
@@ -410,13 +408,17 @@ mod tests {
 
     #[test]
     fn contract_address_validation_accepts_prefixed_hex() {
-        let address = validate_contract_address("0x9a9671441249ee2c364f9b4bc8049e61b082449a").unwrap();
+        let address =
+            validate_contract_address("0x9a9671441249ee2c364f9b4bc8049e61b082449a").unwrap();
         assert_eq!(address, "0x9a9671441249ee2c364f9b4bc8049e61b082449a");
     }
 
     #[test]
     fn contract_args_are_hex_encoded() {
-        assert_eq!(encode_contract_args(&["hello".to_owned(), "7".to_owned()]), "68656c6c6f2c37");
+        assert_eq!(
+            encode_contract_args(&["hello".to_owned(), "7".to_owned()]),
+            "68656c6c6f2c37"
+        );
     }
 
     #[tokio::test]
@@ -448,7 +450,10 @@ mod tests {
         let mut services = MockDeployConfirmationServices::default();
         services.push_err("/tx/0xabc", "pending");
         services.push_err("/tx/0xabc", "pending");
-        services.push_ok("/tx/0xabc", json!({ "tx_hash": "0xabc", "status": "Success" }));
+        services.push_ok(
+            "/tx/0xabc",
+            json!({ "tx_hash": "0xabc", "status": "Success" }),
+        );
 
         services.push_err("/api/contracts/0xdef", "missing");
         services.push_ok("/api/contracts/0xdef", json!({ "address": "0xdef" }));

--- a/crates/dytallix-cli/src/commands/init.rs
+++ b/crates/dytallix-cli/src/commands/init.rs
@@ -97,7 +97,7 @@ where
     println!("  dytallix send {} 100", short_address(&address));
     println!();
     println!("  Sends 100 DRT to any address.");
-    println!("  Gas paid in DRT automatically.");
+    println!("  Gas paid in DGT automatically.");
     println!("  Fee breakdown shown before confirmation.");
     println!("  Run it now to hit Milestone 2.");
     println!();
@@ -107,7 +107,7 @@ where
     println!();
     println!("  dytallix contract deploy ./my_contract.wasm");
     println!();
-    println!("  Gas paid in DRT automatically.");
+    println!("  Gas paid in DGT automatically.");
     println!("  Fee breakdown shown before confirmation.");
     println!("  See docs/getting-started.md for a");
     println!("  complete walkthrough to Milestone 3.");

--- a/crates/dytallix-cli/src/commands/mod.rs
+++ b/crates/dytallix-cli/src/commands/mod.rs
@@ -251,7 +251,7 @@ pub(crate) fn bytes_to_hex(bytes: &[u8]) -> String {
 
 pub(crate) fn hex_to_bytes(raw: &str) -> Result<Vec<u8>> {
     let trimmed = raw.trim();
-    if trimmed.len() % 2 != 0 {
+    if !trimmed.len().is_multiple_of(2) {
         return Err(anyhow!(
             "Invalid hex input. Provide an even number of characters."
         ));

--- a/crates/dytallix-cli/src/commands/mod.rs
+++ b/crates/dytallix-cli/src/commands/mod.rs
@@ -202,6 +202,21 @@ pub(crate) fn format_number(value: u128) -> String {
     out.chars().rev().collect()
 }
 
+/// Formats a micro-denominated token amount using up to 6 decimal places.
+pub(crate) fn format_micro_amount(value: u128) -> String {
+    let whole = value / 1_000_000;
+    let fractional = value % 1_000_000;
+
+    if fractional == 0 {
+        whole.to_string()
+    } else {
+        format!("{whole}.{fractional:06}")
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_owned()
+    }
+}
+
 pub(crate) fn display_path(path: &Path) -> String {
     let home = home_dir();
     if let Ok(stripped) = path.strip_prefix(&home) {

--- a/crates/dytallix-cli/src/commands/send.rs
+++ b/crates/dytallix-cli/src/commands/send.rs
@@ -7,10 +7,12 @@ use dytallix_sdk::transaction::TransactionBuilder;
 use dytallix_sdk::Token;
 
 use crate::commands::{
-    active_entry, active_keypair, configured_client, format_number, humanize_sdk_error,
-    load_keystore, validate_address,
+    active_entry, active_keypair, configured_client, format_micro_amount, format_number,
+    humanize_sdk_error, load_keystore, validate_address,
 };
 use crate::output;
+
+const MICROS_PER_TOKEN: u128 = 1_000_000;
 
 /// Arguments for the `send` command.
 #[derive(Debug, Clone, Args)]
@@ -82,11 +84,14 @@ pub async fn run(args: SendArgs) -> Result<()> {
         .build()
         .map_err(|err| anyhow!(err.to_string()))?;
     let fee = tx.estimate_fee(&client).await.map_err(humanize_sdk_error)?;
-    if account.balance.drt < fee.total_cost_drt {
+
+    let required_fee_micro = fee.total_cost_drt;
+    let available_fee_micro = account.balance.dgt.saturating_mul(MICROS_PER_TOKEN);
+    if available_fee_micro < required_fee_micro {
         return Err(anyhow!(
-			"Insufficient DRT for gas fees. Required: {} DRT. Available: {} DRT. Run dytallix faucet to get more.",
-			format_number(fee.total_cost_drt),
-			format_number(account.balance.drt)
+			"Insufficient DGT for gas fees. Required: {} DGT. Available: {} DGT. Run dytallix faucet to get more.",
+			format_micro_amount(required_fee_micro),
+			format_number(account.balance.dgt)
 		));
     }
 

--- a/crates/dytallix-cli/src/output.rs
+++ b/crates/dytallix-cli/src/output.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use colored::Colorize;
 use dytallix_sdk::FeeEstimate;
 
+use crate::commands::format_micro_amount;
+
 /// Prints a success line, optionally including an elapsed duration.
 pub fn success(message: &str, elapsed: Option<Duration>) {
     println!("{}", format_success(message, elapsed));
@@ -37,7 +39,7 @@ pub fn balance(dgt: u128, drt: u128) {
     println!("{}", format_balance(dgt, drt));
 }
 
-/// Prints a DRT fee estimate with separate compute and bandwidth gas lines.
+/// Prints a DGT fee estimate with separate compute and bandwidth gas lines.
 pub fn fee_breakdown(estimate: &FeeEstimate) {
     println!("{}", format_fee_breakdown(estimate));
 }
@@ -78,12 +80,12 @@ fn format_balance(dgt: u128, drt: u128) -> String {
 
 fn format_fee_breakdown(estimate: &FeeEstimate) -> String {
     format!(
-		"  Fee estimate:\n    Compute (C-Gas):   {} units  {} DRT\n    Bandwidth (B-Gas): {} units  {} DRT\n    Total:             {} DRT",
+		"  Fee estimate:\n    Compute (C-Gas):   {} units  {} DGT\n    Bandwidth (B-Gas): {} units  {} DGT\n    Total:             {} DGT",
 		estimate.c_gas,
-		estimate.c_gas_cost_drt,
+		format_micro_amount(estimate.c_gas_cost_drt),
 		estimate.b_gas,
-		estimate.b_gas_cost_drt,
-		estimate.total_cost_drt
+		format_micro_amount(estimate.b_gas_cost_drt),
+		format_micro_amount(estimate.total_cost_drt)
 	)
 }
 
@@ -119,15 +121,17 @@ mod tests {
     #[test]
     fn fee_breakdown_output_shows_both_gas_dimensions() {
         let estimate = FeeEstimate {
-            c_gas: 21_000,
-            c_gas_cost_drt: 10,
-            b_gas: 512,
-            b_gas_cost_drt: 3,
-            total_cost_drt: 13,
+            c_gas: 1_728,
+            c_gas_cost_drt: 1_728_000,
+            b_gas: 321,
+            b_gas_cost_drt: 321_000,
+            total_cost_drt: 2_049_000,
         };
         let rendered = format_fee_breakdown(&estimate);
         assert!(rendered.contains("C-Gas"));
         assert!(rendered.contains("B-Gas"));
-        assert!(rendered.contains("Total"));
+        assert!(rendered.contains("DGT"));
+        assert!(rendered.contains("1.728"));
+        assert!(rendered.contains("2.049"));
     }
 }

--- a/crates/dytallix-core/src/keypair.rs
+++ b/crates/dytallix-core/src/keypair.rs
@@ -251,9 +251,7 @@ impl DytallixKeypair {
     }
 }
 
-fn ml_dsa_65_private_key_from_bytes(
-    bytes: &[u8],
-) -> Result<ml_dsa_65::PrivateKey, DytallixError> {
+fn ml_dsa_65_private_key_from_bytes(bytes: &[u8]) -> Result<ml_dsa_65::PrivateKey, DytallixError> {
     let private_key = bytes
         .try_into()
         .map_err(|_| DytallixError::InvalidKeySize {

--- a/crates/dytallix-core/src/signature.rs
+++ b/crates/dytallix-core/src/signature.rs
@@ -134,13 +134,13 @@ pub fn batch_verify_mldsa65(
     Ok(results)
 }
 
-fn ml_dsa_65_public_key_from_bytes(
-    pubkey: &[u8],
-) -> Result<ml_dsa_65::PublicKey, DytallixError> {
-    let public_key = pubkey.try_into().map_err(|_| DytallixError::InvalidKeySize {
-        expected: MLDSA65_PUBLIC_KEY_BYTES,
-        got: pubkey.len(),
-    })?;
+fn ml_dsa_65_public_key_from_bytes(pubkey: &[u8]) -> Result<ml_dsa_65::PublicKey, DytallixError> {
+    let public_key = pubkey
+        .try_into()
+        .map_err(|_| DytallixError::InvalidKeySize {
+            expected: MLDSA65_PUBLIC_KEY_BYTES,
+            got: pubkey.len(),
+        })?;
     ml_dsa_65::PublicKey::try_from_bytes(public_key)
         .map_err(|err| DytallixError::InvalidKeypair(err.to_string()))
 }

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -23,8 +23,8 @@ The SDK models two canonical tokens:
 
 | Token | Purpose |
 | --- | --- |
-| `DGT` | Governance and delegation |
-| `DRT` | Gas fees, rewards, and burns |
+| `DGT` | Governance, delegation, and gas fees |
+| `DRT` | Rewards and burns |
 
 Relevant types:
 
@@ -61,7 +61,7 @@ Default behavior:
 
 - Compute gas defaults to `21_000`
 - Bandwidth gas defaults to `data.len() as u64`
-- Fees are always denominated in DRT
+- Fees are always denominated in DGT micro-units.
 
 The fee estimate is represented by
 [`FeeEstimate`](../crates/dytallix-sdk/src/lib.rs) and split into compute and


### PR DESCRIPTION
Fix the CLI fee handling and documentation so transaction fees are treated as DGT micro-units consistently.

What changed:
- Corrected `dytallix send` to compare the estimated fee against the DGT balance in micro-units.
- Fixed fee breakdown output to render the micro-denominated values as whole DGT amounts.
- Updated the init guidance strings to say gas is paid in DGT, not DRT.
- Corrected the core concepts doc to match the actual fee model.

Root cause:
- The CLI was comparing `fee.total_cost_drt` directly against the DRT balance and labeling fee output as DRT, even though the SDK fee estimate is micro-denominated DGT.

Validation:
- `cargo test -p dytallix-cli`