### PR TITLE
Add signed contract deploy/call flow and tighten public repo guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ point the CLI at a direct node or local node with `DYTALLIX_ENDPOINT` or
 See [Getting started](docs/getting-started.md) and the
 [CLI reference](docs/cli-reference.md) for the full flow.
 
+## Repo Boundaries
+
+This repository ships the Rust SDK, core cryptography crate, and the
+`dytallix` CLI.
+
+It does include the client code that talks to the live faucet endpoint, but it
+does not contain the faucet backend implementation. The live faucet backend
+source is published separately in
+[dytallix-faucet](https://github.com/DytallixHQ/dytallix-faucet).
+
 ## Documentation Map
 
 - [Docs hub](docs/README.md) - overview of every repo documentation page
@@ -129,56 +139,13 @@ See [Getting started](docs/getting-started.md) and the
 - [FAQ](docs/faq.md) - operational and product questions
 - [Examples](examples/README.md) - runnable examples and prerequisites
 
-## Download
-
-- GitHub Releases: https://github.com/DytallixHQ/dytallix-sdk/releases
-- Build from source: `cargo build --release --bin dytallix`
-- Install from GitHub: `cargo install --git https://github.com/DytallixHQ/dytallix-sdk.git dytallix-cli --bin dytallix`
-
-Release tags matching `v*` build downloadable CLI archives for Linux, macOS
-(Intel and Apple Silicon), and Windows through GitHub Actions.
-
-## First Keypair
-
-The default `dytallix-sdk` crate now supports the shortest path to a real
-post-quantum identity:
-
-```rust
-use dytallix_sdk::{DAddr, DytallixKeypair};
-
-fn main() {
-    let keypair = DytallixKeypair::generate();
-    let addr = DAddr::from_public_key(keypair.public_key()).unwrap();
-    println!("{addr}");
-}
-```
-
-Add it to a project with:
-
-```bash
-cargo add dytallix-sdk
-```
-
-For network client and faucet support, enable the `network` feature:
-
-```bash
-cargo add dytallix-sdk --features network
-```
-
-Repository examples:
-
-```bash
-cargo run -p dytallix-sdk --example first-keypair
-cargo run -p dytallix-sdk --features network --example first-transaction
-```
-
 ## DytallixHQ Repositories
 
 - [dytallix-sdk](https://github.com/DytallixHQ/dytallix-sdk) - this repository
 - [dytallix-contracts](https://github.com/DytallixHQ/dytallix-contracts) - protocol contracts
 - [dytallix-docs](https://github.com/DytallixHQ/dytallix-docs) - broader documentation
-- [dytallix-explorer](https://github.com/DytallixHQ/dytallix-explorer) - public explorer service repository
-- [dytallix-faucet](https://github.com/DytallixHQ/dytallix-faucet) - public faucet service repository
+- [dytallix-explorer](https://github.com/DytallixHQ/dytallix-explorer) - explorer surface documentation repo
+- [dytallix-faucet](https://github.com/DytallixHQ/dytallix-faucet) - public faucet backend source
 
 ## External Links
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,12 @@ Do not open a public GitHub issue for security vulnerabilities.
 
 ## Reporting a Vulnerability
 
-Report security issues by sending a direct message to the maintainer on
-[Discord](https://discord.gg/eyVvu5kmPG).
+Report security issues privately through GitHub Security Advisories or by email
+to [hello@dytallix.com](mailto:hello@dytallix.com).
+
+If you use GitHub, open a private advisory draft from the repository's
+Security tab. Use email when you need to share details before an advisory is
+opened.
 
 Include:
 
@@ -18,7 +22,7 @@ Include:
 - Your severity and exploitability assessment
 - Whether you want public credit when the issue is disclosed
 
-You should receive an initial response within 24 hours.
+We aim to acknowledge receipt within 3 business days.
 
 ## What Happens Next
 
@@ -61,3 +65,5 @@ English.
 
 We follow responsible disclosure. Please allow a reasonable window to develop
 and ship a fix before public disclosure. We will work with you on timing.
+
+Do not use Discord or public issues for vulnerability reporting.

--- a/crates/dytallix-cli/src/commands/contract.rs
+++ b/crates/dytallix-cli/src/commands/contract.rs
@@ -5,16 +5,23 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
+use dytallix_sdk::transaction::{Message, Transaction};
 use serde_json::{json, Value};
 
 use crate::commands::{
-    active_entry, bytes_to_hex, display_path, hex_to_bytes, load_keystore, raw_get_json,
-    raw_post_json, read_bytes,
+    active_entry, active_keypair, bytes_to_hex, configured_client, display_path,
+    format_micro_amount, format_number, hex_to_bytes, humanize_sdk_error, load_keystore,
+    raw_get_json, raw_post_json, read_bytes,
 };
 use crate::output;
 
 const DEPLOY_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(15);
 const DEPLOY_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_millis(750);
+const CALL_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(15);
+const CALL_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_millis(750);
+const CONTRACT_DEPLOY_GAS_LIMIT: u64 = 1_000_000;
+const CONTRACT_CALL_GAS_LIMIT: u64 = 1_000_000;
+const MICROS_PER_TOKEN: u128 = 1_000_000;
 
 /// Arguments for the `contract` command.
 #[derive(Debug, Clone, Args)]
@@ -68,15 +75,16 @@ pub async fn run(args: ContractArgs) -> Result<()> {
 
 async fn deploy(wasm_file: PathBuf) -> Result<()> {
     let wasm = validated_wasm_bytes(&wasm_file)?;
-    let keystore = load_keystore()?;
-    let sender = active_entry(&keystore)?.address.to_string();
+    let signed = sign_contract_transaction(Message::ContractDeploy {
+        from: active_sender()?.to_string(),
+        code: bytes_to_hex(&wasm),
+        gas_limit: CONTRACT_DEPLOY_GAS_LIMIT,
+        initial_state: None,
+    })
+    .await?;
     let value = raw_post_json(
         "/contracts/deploy",
-        &json!({
-            "deployer": sender,
-            "code": bytes_to_hex(&wasm),
-            "gas_limit": 1_000_000u64,
-        }),
+        &json!({ "signed_tx": signed }),
     )
     .await?;
     let tx_hash = value
@@ -140,22 +148,50 @@ async fn deploy(wasm_file: PathBuf) -> Result<()> {
 
 async fn call(address: String, method: String, args: Vec<String>) -> Result<()> {
     let contract = validate_contract_address(&address)?;
+    let signed = sign_contract_transaction(Message::ContractCall {
+        from: active_sender()?.to_string(),
+        address: contract.clone(),
+        method: method.clone(),
+        args: (!args.is_empty()).then(|| encode_contract_args(&args)),
+        gas_limit: CONTRACT_CALL_GAS_LIMIT,
+    })
+    .await?;
     let value = raw_post_json(
         "/contracts/call",
-        &json!({
-            "address": contract,
-            "method": method,
-            "args": encode_contract_args(&args),
-            "gas_limit": 1_000_000u64,
-        }),
+        &json!({ "signed_tx": signed }),
     )
     .await?;
-    if let Some(tx_hash) = value.get("tx_hash").and_then(|raw| raw.as_str()) {
+    let tx_hash = value
+        .get("tx_hash")
+        .and_then(|raw| raw.as_str())
+        .map(str::to_owned);
+    if let Some(tx_hash) = tx_hash.as_deref() {
         output::tx_hash(tx_hash);
     }
+
+    if let Some(tx_hash) = tx_hash.as_deref() {
+        let mut services = RealDeployConfirmationServices;
+        if wait_for_transaction_confirmation(
+            &mut services,
+            tx_hash,
+            CALL_CONFIRMATION_TIMEOUT,
+            CALL_CONFIRMATION_POLL_INTERVAL,
+        )
+        .await?
+        {
+            output::success("Contract call confirmed", None);
+            println!("Indexed via: /tx/{tx_hash}");
+        } else {
+            output::warning(&format!(
+                "Contract call submitted but was not indexed within {:.1}s.",
+                CALL_CONFIRMATION_TIMEOUT.as_secs_f64()
+            ));
+        }
+    }
+
     output::section("Contract call");
     println!("{}", serde_json::to_string_pretty(&value)?);
-    output::success("Contract call executed", None);
+    output::success("Contract call submitted", None);
     Ok(())
 }
 
@@ -232,6 +268,56 @@ fn print_canonical_contract_verification(address: Option<&str>) {
     }
 }
 
+fn active_sender() -> Result<dytallix_core::address::DAddr> {
+    let keystore = load_keystore()?;
+    Ok(active_entry(&keystore)?.address.clone())
+}
+
+async fn sign_contract_transaction(
+    message: Message,
+) -> Result<dytallix_sdk::transaction::SignedTransaction> {
+    let keystore = load_keystore()?;
+    let active = active_entry(&keystore)?;
+    let keypair = active_keypair(&keystore)?;
+    let client = configured_client().await?;
+    let account = client
+        .get_account(&active.address)
+        .await
+        .map_err(humanize_sdk_error)?;
+
+    let gas_limit = match &message {
+        Message::ContractDeploy { gas_limit, .. } | Message::ContractCall { gas_limit, .. } => {
+            *gas_limit
+        }
+        _ => return Err(anyhow!("unsupported contract message type")),
+    };
+
+    let tx = Transaction {
+        chain_id: "dyt-local-1".to_string(),
+        nonce: account.nonce,
+        msgs: vec![message],
+        fee: 0,
+        memo: String::new(),
+        c_gas_limit: gas_limit,
+        b_gas_limit: 0,
+    };
+    let fee = tx.estimate_fee(&client).await.map_err(humanize_sdk_error)?;
+    let required_fee_micro = fee.total_cost_drt;
+    let available_fee_micro = account.balance.dgt.saturating_mul(MICROS_PER_TOKEN);
+    if available_fee_micro < required_fee_micro {
+        return Err(anyhow!(
+            "Insufficient DGT for gas fees. Required: {} DGT. Available: {} DGT. Run dytallix faucet to get more.",
+            format_micro_amount(required_fee_micro),
+            format_number(account.balance.dgt)
+        ));
+    }
+
+    output::fee_breakdown(&fee);
+    tx.with_fee_micro(required_fee_micro)
+        .sign(&keypair)
+        .map_err(humanize_sdk_error)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeployConfirmationVia {
     Transaction,
@@ -301,6 +387,29 @@ where
 
         if started.elapsed() >= timeout {
             return Ok(None);
+        }
+
+        services.wait(poll_interval).await;
+    }
+}
+
+async fn wait_for_transaction_confirmation<S>(
+    services: &mut S,
+    tx_hash: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<bool>
+where
+    S: DeployConfirmationServices,
+{
+    let started = Instant::now();
+    loop {
+        if services.get_json(&format!("/tx/{tx_hash}")).await.is_ok() {
+            return Ok(true);
+        }
+
+        if started.elapsed() >= timeout {
+            return Ok(false);
         }
 
         services.wait(poll_interval).await;

--- a/crates/dytallix-sdk/src/transaction.rs
+++ b/crates/dytallix-sdk/src/transaction.rs
@@ -324,6 +324,23 @@ pub enum Message {
     },
     /// An arbitrary data payload anchored on-chain.
     Data { from: String, data: String },
+    /// A signed WASM contract deployment.
+    ContractDeploy {
+        from: String,
+        code: String,
+        gas_limit: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initial_state: Option<String>,
+    },
+    /// A signed contract call.
+    ContractCall {
+        from: String,
+        address: String,
+        method: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        args: Option<String>,
+        gas_limit: u64,
+    },
 }
 
 impl Token {
@@ -377,6 +394,9 @@ fn message_execution_gas(message: &Message) -> u64 {
             .saturating_add(KV_WRITE_GAS)
             .saturating_add(KV_WRITE_GAS),
         Message::Data { data, .. } => data.len() as u64,
+        Message::ContractDeploy { gas_limit, .. } | Message::ContractCall { gas_limit, .. } => {
+            *gas_limit
+        }
     }
 }
 
@@ -385,13 +405,16 @@ impl Message {
         match self {
             Self::Send { from, .. } => from,
             Self::Data { from, .. } => from,
+            Self::ContractDeploy { from, .. } => from,
+            Self::ContractCall { from, .. } => from,
         }
     }
 
     fn send_recipient(&self) -> Option<&str> {
         match self {
             Self::Send { to, .. } => Some(to),
-            Self::Data { .. } => None,
+            Self::Data { .. } | Self::ContractDeploy { .. } => None,
+            Self::ContractCall { address, .. } => Some(address),
         }
     }
 }


### PR DESCRIPTION
## Summary

This branch does two things:

1. Adds signed contract deploy and signed contract call support to the CLI/SDK transaction surface
2. Tightens the public-facing repo documentation and security disclosure path

## What Changed

- added `ContractDeploy` and `ContractCall` message variants to the SDK transaction model
- updated the CLI `contract deploy` and `contract call` flows to:
  - build signed transactions instead of posting unsigned bodies
  - estimate fees through the configured client
  - check available DGT before submission
  - submit `signed_tx` payloads
  - wait for transaction indexing after contract calls
- clarified the README so it no longer implies crates.io-style install paths that are not currently real
- clarified the faucet boundary: this repo ships the faucet client path, not the faucet backend implementation
- replaced Discord-first vulnerability reporting with GitHub Security Advisories or `hello@dytallix.com`

## Why

The branch makes the contract workflow consistent with the signed transaction model already used elsewhere, and it removes public-facing trust gaps in the repo docs and security policy.

## Reviewer Notes

The branch diff includes both:
- the earlier signed contract submit flow
- the later publishability/docs/security cleanup

## Validation

- branch pushed successfully to `signed-contract-submit-flow`
- local Rust checks were not re-run in this session after the docs/security commit
